### PR TITLE
feat: only show dropdown if input widget currently has focus

### DIFF
--- a/textual_autocomplete/_autocomplete.py
+++ b/textual_autocomplete/_autocomplete.py
@@ -403,7 +403,9 @@ Dropdown .autocomplete--selection-cursor {
             )
 
         self.child.matches = matches
-        self.display = len(matches) > 0 and value != ""
+        self.display = (
+            len(matches) > 0 and value != "" and self.input_widget.has_focus()
+        )
         self.cursor_home()
         self.reposition(input_cursor_position)
         self.child.refresh()


### PR DESCRIPTION
Fixes #7 by only setting `self.display` if the input widget has focus