### PR TITLE
feat: only react to key events (and stop them) when dropdown is displayed

### DIFF
--- a/textual_autocomplete/_autocomplete.py
+++ b/textual_autocomplete/_autocomplete.py
@@ -185,6 +185,10 @@ AutoComplete {
         self.dropdown.display = False
 
     def on_key(self, event: events.Key) -> None:
+        if not self.dropdown.display:
+            # only respond and stop the event if the dropdown is open
+            return
+
         key = event.key
         if key == "down":
             self.dropdown.cursor_down()


### PR DESCRIPTION
Where used in screens that also have event handers for `Escape` or the arrow keys, the `Dropdown` widget prevents those operating even when it isn't open.

This PR changes that so that the dropdown will respond/stop to these keys only when it is open.