### PR TITLE
Add license metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,20 @@ dependencies = [
     "typing-extensions>=4.5.0",
 ]
 requires-python = ">=3.9.0"
+license= "MIT"
+license-files = ["LICENSE"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
 
 [tool.uv]
 dev-dependencies = [


### PR DESCRIPTION
PyPi doesn't identify license info unless it's included in the metadata.  Add the license info and some other useful classifiers based on the project and the `textual` project.

Fixes: https://github.com/darrenburns/textual-autocomplete/issues/28