### PR TITLE
Use standardized dependency-groups instead legacy dev-dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,22 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-[tool.uv]
-dev-dependencies = [
-    "mypy",
+[dependency-groups]
+dev = [
+    "textual-dev",
+    {include-group = "test"},
+    {include-group = "lint"},
+]
+test = [
     "pytest>=8.3.5",
     "pytest-asyncio>=0.24.0",
     "pytest-textual-snapshot>=1.1.0",
     "pytest-xdist>=3.6.1",
-    "textual-dev",
 ]
+lint = [
+    "mypy",
+]
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["textual_autocomplete"]


### PR DESCRIPTION
After PEP 735 was accepted uv started to use dependency-groups. Usage of dev-dependencies field is now depricated and will be removed in future uv releases. 

The main reason behind this PR is that it is needed for a packaging your python module for linux distributions.